### PR TITLE
Update external links (graphopper, openbikemap)

### DIFF
--- a/felhasznalas.shtml
+++ b/felhasznalas.shtml
@@ -89,6 +89,10 @@
 						OSRM - OpenSource Routing Machine</a> - autós, kerékpáros, gyalogos tervező
 				</li>
 				<li>
+					<a href="https://graphhopper.com/maps/">
+						Graphhopper</a> - autós, kerékpáros, gyalogos tervező, külön teherautós és más módokkal
+				</li>
+				<li>
 					<a href="https://www.freemap.sk/">Freemap.sk</a>
 					- autós, biciklis, gyalogos útvonal tervező. POI-k keresése stb.  Magyarul is működik.
 				</li>

--- a/letoltesek.shtml
+++ b/letoltesek.shtml
@@ -59,7 +59,7 @@
 
 		<p>Magyarország vagy európai térképek letöltése: <a href="https://www.openhiking.eu/hu/">OpenHiking.eu</a>
 		vagy <a href="http://garmin.openstreetmap.nl/">OpenStreetMap.nl</a>.
-		Bringázáshoz próbáld ki az <a href="https://www.osmbikemap.szerako.hu">OSM Bike Map</a> térképét.</p>
+		Bringázáshoz próbáld ki az <a href="https://www.openbikemap.szerako.hu">Open Bike Map</a> térképét.</p>
 
 		<hr />
 


### PR DESCRIPTION
Add new link to routing engine graphhopper.
osmbikemap's new address will be openbikemap.